### PR TITLE
bug - fixed mispelled var

### DIFF
--- a/roles/na_ontap_vserver_delete/README.md
+++ b/roles/na_ontap_vserver_delete/README.md
@@ -25,8 +25,8 @@ This role expects the following variables to be set:
 - vserver_name: name of vserver to delete.
 
 In order to delete a CIFS server, the following variables are required
-- ad_admin_user_name: AD admin user name
-- ad_admin_password: AD admin password
+- cifs_ad_admin_user_name: AD admin user name
+- cifs_ad_admin_password: AD admin password
 
 The following variables are preset but can be changed
 - https: true 

--- a/roles/na_ontap_vserver_delete/defaults/main.yml
+++ b/roles/na_ontap_vserver_delete/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for ansible_collections/netapp/ontap/roles/na_ontap_vserver_delete
 debug_level: 0
-cif_force_delete: false
+cifs_force_delete: false
 enable_check_mode: false
 confirm_before_removing_cifs_server: true
 confirm_before_removing_igroups: true


### PR DESCRIPTION
##### SUMMARY
Variable "cifs_force_delete" in netapp.ontap/roles/na_ontap_vserver_delete/defaults/main.yml was spelled wrong - cif_force_delete, causing the role to fail when deleting an SVM with CIFs and not setting the variable separately 

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
