### PR TITLE
Documentation: Corrected cifs variable names

### DIFF
--- a/roles/na_ontap_vserver_delete/README.md
+++ b/roles/na_ontap_vserver_delete/README.md
@@ -25,8 +25,8 @@ This role expects the following variables to be set:
 - vserver_name: name of vserver to delete.
 
 In order to delete a CIFS server, the following variables are required
-- ad_admin_user_name: AD admin user name
-- ad_admin_password: AD admin password
+- cifs_ad_admin_user_name: AD admin user name
+- cifs_ad_admin_password: AD admin password
 
 The following variables are preset but can be changed
 - https: true 


### PR DESCRIPTION
##### SUMMARY
Documentation "netapp.ontap/roles/na_ontap_vserver_delete/README.md" listed the wrong variables for cifs admin user and password

##### ISSUE TYPE
- Docs Pull Request