### PR TITLE
Handle 'support' field new values in newer ONTAP versions

### DIFF
--- a/plugins/modules/na_ontap_autosupport.py
+++ b/plugins/modules/na_ontap_autosupport.py
@@ -288,11 +288,12 @@ reminder,max-http-size,max-smtp-size,remove-private-data,ondemand-server-url,sup
                 self.module.fail_json(msg=error)
 
             asup_info = {}
-            for param in ('transport', 'support', 'mail_hosts', 'proxy_url', 'retry_count',
+            for param in ('transport', 'mail_hosts', 'proxy_url', 'retry_count',
                           'max_http_size', 'max_smtp_size', 'noteto', 'validate_digital_certificate'):
                 if param in records[0]:
                     asup_info[param] = records[0][param]
 
+            asup_info['support'] = True if records[0]['support'] in ['enable', True] else False
             asup_info['node_name'] = records[0]['node'] if 'node' in records[0] else ""
             asup_info['post_url'] = records[0]['url'] if 'url' in records[0] else ""
             asup_info['from_address'] = records[0]['from'] if 'from' in records[0] else ""

--- a/plugins/modules/na_ontap_autosupport.py
+++ b/plugins/modules/na_ontap_autosupport.py
@@ -293,7 +293,7 @@ reminder,max-http-size,max-smtp-size,remove-private-data,ondemand-server-url,sup
                 if param in records[0]:
                     asup_info[param] = records[0][param]
 
-            asup_info['support'] = True if records[0]['support'] in ['enable', True] else False
+            asup_info['support'] = records[0]['support'] in ['enable', True]
             asup_info['node_name'] = records[0]['node'] if 'node' in records[0] else ""
             asup_info['post_url'] = records[0]['url'] if 'url' in records[0] else ""
             asup_info['from_address'] = records[0]['from'] if 'from' in records[0] else ""


### PR DESCRIPTION
Handle newer ONTAP versions replying a 'support' field with a value of 'enable' instead of 'True', which causes a type error between bool and str as per issue #71

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #71 where recent ONTAP versions have changed API behavior, and the 'support' field is not true/false anymore, but 'enable' or 'disable'
Very minimal patch that simply validates which values are unambiguously true, and assumes other values would be false (likely False or 'disable')
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
na_ontap_autosupport