### PR TITLE
Update README.md

### DIFF
--- a/roles/na_ontap_vserver_create/README.md
+++ b/roles/na_ontap_vserver_create/README.md
@@ -72,7 +72,7 @@ Example Playbook
       prompt: domain admin password (enter if skipped)
   vars_files:
     - globals.yml
-  roles
+  roles:
   - na_ontap_vserver_create
 ```
 I use a globals file to hold my variables.


### PR DESCRIPTION
Missing colon after 'roles' in the Example playbook.

##### SUMMARY
Missing colon after 'roles' in the Example playbook.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
README.md for netapp.ontap/roles/na_ontap_vserver_create

##### ADDITIONAL INFORMATION
-
```
