### PR TITLE
Add management-log-forwarding to known_services

### DIFF
--- a/plugins/modules/na_ontap_service_policy.py
+++ b/plugins/modules/na_ontap_service_policy.py
@@ -64,13 +64,14 @@ options:
     choices: ['cluster', 'svm']
   known_services:
     description:
-      - List of known services in 9.11.1
+      - List of known services in 9.12.1
       - An error is raised if any service in C(services) is not in this list or C(new_services).
       - Modify this list to restrict the services you want to support if needed.
     default: [cluster_core, intercluster_core, management_core, management_autosupport, management_bgp, management_ems, management_https, management_http,
               management_ssh, management_portmap, data_core, data_nfs, data_cifs, data_flexcache, data_iscsi, data_s3_server, data_dns_server,
               data_fpolicy_client, management_ntp_client, management_dns_client, management_ad_client, management_ldap_client, management_nis_client,
-              management_snmp_server, management_rsh_server, management_telnet_server, management_ntp_server, data_nvme_tcp, backup_ndmp_control]
+              management_snmp_server, management_rsh_server, management_telnet_server, management_ntp_server, data_nvme_tcp, backup_ndmp_control,
+              management_log_forwarding]
     type: list
     elements: str
     version_added: 22.0.0
@@ -184,7 +185,7 @@ class NetAppOntapServicePolicy:
                                          'data_flexcache', 'data_iscsi', 'data_s3_server', 'data_dns_server', 'data_fpolicy_client', 'management_ntp_client',
                                          'management_dns_client', 'management_ad_client', 'management_ldap_client', 'management_nis_client',
                                          'management_snmp_server', 'management_rsh_server', 'management_telnet_server', 'management_ntp_server',
-                                         'data_nvme_tcp', 'backup_ndmp_control']),
+                                         'data_nvme_tcp', 'backup_ndmp_control', 'management_log_forwarding']),
             additional_services=dict(type='list', elements='str')
         ))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update na_ontap_service_policy module to support management-log-forwarding service, which was added in ONTAP 9.12.1.  
https://docs.netapp.com/us-en/ontap/networking/lifs_and_service_policies96.html
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
na_ontap_service_policy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
