### PR TITLE
The Slack community moved to Discord, update references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,12 +20,12 @@ body:
 
 
       **Tip:** If you are seeking community support, please consider
-      [Join our Slack community][ML||IRC].
+      [Join our Discord community][ML||IRC].
 
 
 
       [ML||IRC]:
-      https://join.slack.com/t/netapppub/shared_invite/zt-njcjx2sh-1VR2mEDvPcJAmPutOnP~mg
+      https://discord.gg/NetApp
 
       [issue search]: ../search?q=is%3Aissue&type=issues
 

--- a/plugins/modules/na_ontap_info.py
+++ b/plugins/modules/na_ontap_info.py
@@ -213,7 +213,7 @@ options:
         - missing_vserver_api_error - most likely the API is available at cluster level but not vserver level.
         - rpc_error - some queries are failing because the node cannot reach another node in the cluster.
         - key_error - a query is failing because the returned data does not contain an expected key.
-        - for key errors, make sure to report this in Slack.  It may be a change in a new ONTAP version.
+        - for key errors, make sure to report this in Discord.  It may be a change in a new ONTAP version.
         - other_error - anything not in the above list.
         - always will continue on any error, never will fail on any error, they cannot be used with any other keyword.
         type: list


### PR DESCRIPTION
##### SUMMARY
Update references to the Slack community. The existing link didn't work anymore since [it moved to Discord](https://netapp.io/2022/08/17/the-pub-slack-is-moving-to-discord/).

##### ISSUE TYPE
- Docs Pull Request


