### PR TITLE
na_ontap_rest_cli - Return command output for GET/OPTIONS verbs during check mode 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The following modules do not have REST equivalent APIs. They will stop working o
   - na_ontap_volume - new option `activity_tracking` added in REST, requires ONTAP 9.10 or later.
   - na_ontap_snapshot_policy - new option `retention_period` added in REST, requires ONTAP 9.12 or later.
   - na_ontap_security_key_manager - added warning message in REST when passphrase is not changed.
+  - na_ontap_rest_cli - return command output for GET and OPTIONS verbs during check mode.
 
 ### Bug Fixes
   - na_ontap_export_policy_rule - fix issue with idempotency in REST.

--- a/changelogs/fragments/github-214.yml
+++ b/changelogs/fragments/github-214.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - na_ontap_rest_cli - return command output for GET and OPTIONS verbs during check mode.

--- a/plugins/modules/na_ontap_rest_cli.py
+++ b/plugins/modules/na_ontap_rest_cli.py
@@ -137,7 +137,7 @@ class NetAppONTAPCommandREST():
     def apply(self):
         ''' calls the command and returns raw output '''
         changed = False if self.verb in ['GET', 'OPTIONS'] else True
-        if self.module.check_mode:
+        if self.module.check_mode and self.verb in ['POST', 'PATCH', 'DELETE']:
             output = "Would run command: '%s'" % str(self.command)
         else:
             output = self.run_command()

--- a/tests/unit/plugins/modules/test_na_ontap_rest_cli.py
+++ b/tests/unit/plugins/modules/test_na_ontap_rest_cli.py
@@ -98,13 +98,14 @@ def test_check_mode():
     module_args = {'verb': 'GET'}
     register_responses([
         ('GET', 'cluster', SRR['is_rest']),
+        ('GET', 'private/cli/volume', SRR['is_rest'])
     ])
     my_obj = create_module(my_module, DEFAULT_ARGS, module_args)
     my_obj.module.check_mode = True
     result = expect_and_capture_ansible_exception(my_obj.apply, 'exit')
     assert result['changed'] is False
     msg = "Would run command: 'volume'"
-    assert msg in result['msg']
+    assert msg not in result['msg']
 
 
 def test_negative_verb():

--- a/tests/unit/plugins/modules/test_na_ontap_rest_cli.py
+++ b/tests/unit/plugins/modules/test_na_ontap_rest_cli.py
@@ -98,7 +98,7 @@ def test_check_mode():
     module_args = {'verb': 'GET'}
     register_responses([
         ('GET', 'cluster', SRR['is_rest']),
-        ('GET', 'private/cli/volume', SRR['is_rest'])
+        ('GET', 'private/cli/volume', SRR['empty_good'])
     ])
     my_obj = create_module(my_module, DEFAULT_ARGS, module_args)
     my_obj.module.check_mode = True


### PR DESCRIPTION
##### SUMMARY
Running GET or OPTIONS verbs via the `na_ontap_rest_cli` module should return the command output instead of  "Would run command:" when running the module under check mode.  All commands using these verbs are guaranteed to not make a change.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
na_ontap_rest_cli

##### ADDITIONAL INFORMATION
I validated locally that the change worked as intended and I updated the unit test so that it would pass.  That said, I tried to add a test-case to cover POST/PATCH/DELETE under check mode and I couldn't figure it out.  I need some assistance in this area.  I'm not familiar with all of the mocking that happens.

```yaml
% ansible-playbook test_playbook.yml --check

- name: Get CLI output
  netapp.ontap.na_ontap_rest_cli:
    <<: *login
    command: cluster
    verb: GET
  register: cli_output

- debug: var=cli_output


# Before
TASK [Get CLI output] ******************************
ok: [cluster1]

TASK [debug] ***************************************
ok: [cluster1] => {
    "cli_output": {
        "changed": false,
        "failed": false,
        "msg": "Would run command: 'cluster'"
    }
}

# After
TASK [Get CLI output] **************************************
ok: [cluster1]

TASK [debug] ***********************************************
ok: [cluster1] => {
    "cli_output": {
        "changed": false,
        "failed": false,
        "msg": {
            "num_records": 2,
            "records": [
                {
                    "node": "cluster1a"
                },
                {
                    "node": "cluster1b"
                }
            ]
        }
    }
}
```
