### PR TITLE
Allow totp for second_authentication_method in na_ontap_user

### DIFF
--- a/plugins/modules/na_ontap_user.py
+++ b/plugins/modules/na_ontap_user.py
@@ -79,7 +79,7 @@ options:
       second_authentication_method:
         description: when using ssh, optional additional authentication method for MFA.
         type: str
-        choices: ['none', 'password', 'publickey', 'nsswitch']
+        choices: ['none', 'password', 'publickey', 'nsswitch', 'totp']
   authentication_method:
     description:
       - Authentication method for the application.  If you need more than one method, use C(application_dicts).
@@ -295,7 +295,7 @@ class NetAppOntapUser:
                                                                  'sp', 'service-processor', 'service_processor', 'ssh', 'telnet'],),
                                        authentication_methods=dict(required=True, type='list', elements='str',
                                                                    choices=['community', 'password', 'publickey', 'domain', 'nsswitch', 'usm', 'cert', 'saml']),
-                                       second_authentication_method=dict(type='str', choices=['none', 'password', 'publickey', 'nsswitch']))),
+                                       second_authentication_method=dict(type='str', choices=['none', 'password', 'publickey', 'nsswitch', 'totp']))),
             authentication_method=dict(type='str',
                                        choices=['community', 'password', 'publickey', 'domain', 'nsswitch', 'usm', 'cert', 'saml']),
             set_password=dict(type='str', no_log=True),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

TOTP is now a valid second authentication option when creating users. The REST API accepts it, thus adding it as an option to the user module as well as updating the documentation section to reflect this.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
na_ontap_user

##### ADDITIONAL INFORMATION

None