### PR TITLE
Fixed type in argument_spec for na_ontap_volume to provide and valida…

### DIFF
--- a/plugins/modules/na_ontap_volume.py
+++ b/plugins/modules/na_ontap_volume.py
@@ -247,6 +247,7 @@ options:
     description:
       - The volume type, either read-write (RW) or data-protection (DP).
     type: str
+    choices: ['RW', 'DP']
 
   export_policy:
     description:


### PR DESCRIPTION
…te choices

##### SUMMARY

While trying to set up snapmirror with Ansible I noticed that the type argument in the na_ontap_volume module only allows 2 values (RW and DR) but the argument_spec doesn't reflect this. This PR fixes that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
na_ontap_volume
