### PR TITLE
fix: na_ontap_export_policy_rule fails due to "Error multiple records exist for query.."

### DIFF
--- a/plugins/modules/na_ontap_export_policy_rule.py
+++ b/plugins/modules/na_ontap_export_policy_rule.py
@@ -643,6 +643,8 @@ class NetAppontapExportRule:
     def create_body(self, params):
         body = self.create_body_or_query_common(params)
         # lists
+        if params.get('rule_index') is not None:
+            body['index'] = self.parameters['rule_index']
         if params.get('protocol'):
             body['protocols'] = self.parameters['protocol']
         if params.get('super_user_security'):
@@ -699,7 +701,7 @@ class NetAppontapExportRule:
         cd_action = self.na_helper.get_cd_action(current, self.parameters)
         # if rule_index is not None, see if we need to re-index an existing rule
         # the existing rule may be indexed by from_rule_index or we can match the attributes
-        if cd_action == 'create' and self.parameters.get('rule_index'):
+        if cd_action == 'create' and self.parameters.get('rule_index') and self.parameters.get('from_rule_index') is not None:
             from_current = self.get_export_policy_rule(self.parameters.get('from_rule_index'))
             rename = self.na_helper.is_rename_action(from_current, current)
             if rename is None and self.parameters.get('from_rule_index') is not None:


### PR DESCRIPTION
##### SUMMARY
- Including the rule_index in the create_body() to comply with Ontap 9.15 and later
- enhance the interal ..`cd_action == 'create'`, which ignores a given index_rule in the current version
Fixes #304 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
na_ontap_export_policy_rule.py

##### ADDITIONAL INFORMATION
https://kb.netapp.com/on-prem/ontap/da/NAS/NAS-Issues/CONTAP-68882
https://kb.netapp.com/on-prem/ontap/da/NAS/NAS-KBs/REST_API_Fails_to_Create_NFS_Export_Policy_Rules_with_HTTP_409_Conflict

Detailed steps to reproduce are explained in the issue #304 
