### PR TITLE
add amqp application support to na_ontap_user

### DIFF
--- a/plugins/modules/na_ontap_user.py
+++ b/plugins/modules/na_ontap_user.py
@@ -68,7 +68,7 @@ options:
       application:
         description: name of the application.
         type: str
-        choices: ['console', 'http','ontapi','rsh','snmp','service_processor','service-processor','sp','ssh','telnet']
+        choices: ['amqp', 'console', 'http','ontapi','rsh','snmp','service_processor','service-processor','sp','ssh','telnet']
         required: true
       authentication_methods:
         description: list of authentication methods for the application (see C(authentication_method)).
@@ -286,12 +286,12 @@ class NetAppOntapUser:
             name=dict(required=True, type='str'),
 
             application_strs=dict(type='list', elements='str', aliases=['application', 'applications'],
-                                  choices=['console', 'http', 'ontapi', 'rsh', 'snmp',
+                                  choices=['amqp', 'console', 'http', 'ontapi', 'rsh', 'snmp',
                                            'sp', 'service-processor', 'service_processor', 'ssh', 'telnet'],),
             application_dicts=dict(type='list', elements='dict',
                                    options=dict(
                                        application=dict(required=True, type='str',
-                                                        choices=['console', 'http', 'ontapi', 'rsh', 'snmp',
+                                                        choices=['amqp', 'console', 'http', 'ontapi', 'rsh', 'snmp',
                                                                  'sp', 'service-processor', 'service_processor', 'ssh', 'telnet'],),
                                        authentication_methods=dict(required=True, type='list', elements='str',
                                                                    choices=['community', 'password', 'publickey', 'domain', 'nsswitch', 'usm', 'cert', 'saml']),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds amqp application support to the na_ontap_user module. amqp was added in ONTAP 9.9.1 and is now required for ActiveIQ Unified Manager connections.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
na_ontap_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
