### PR TITLE
Update condition for fcp variable check

### DIFF
--- a/roles/na_ontap_vserver_create/tasks/main.yml
+++ b/roles/na_ontap_vserver_create/tasks/main.yml
@@ -88,7 +88,7 @@
     validate_certs: "{{ validate_certs }}"
   with_items:
     "{{ lifs }}"
-  when: lifs != None
+  when: lifs is defined and (lifs | length) > 0
 - name: Add default route
   netapp.ontap.na_ontap_net_routes:
     state: present
@@ -103,7 +103,7 @@
     validate_certs: "{{ validate_certs }}"
   with_items:
     "{{ gateway }}"
-  when: gateway != None
+  when: gateway is defined
 - name: Create DNS
   netapp.ontap.na_ontap_dns:
     state: present
@@ -117,7 +117,7 @@
     validate_certs: "{{ validate_certs }}"
   with_items:
     "{{ vserver_dns }}"
-  when: vserver_dns !=None
+  when: vserver_dns is defined
 - name: Create CIFS Server
   netapp.ontap.na_ontap_cifs_server:
     state: present
@@ -136,7 +136,7 @@
     validate_certs: "{{ validate_certs }}"
   with_items:
     "{{ cifs }}"
-  when: cifs != None
+  when: cifs is defined and (cifs | length) > 0
 - name: Create NFS Server
   netapp.ontap.na_ontap_nfs:
     state: present


### PR DESCRIPTION


##### SUMMARY
Because the old "with_items" variable is used here. To ensure that this task not running check if the condition is not "!="

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Role na_ontap_vserver_create fixed if no fcp is defined

##### ADDITIONAL INFORMATION
fatal: [netapp-simulator]: FAILED! => {
    "changed": false,
    "msg": "Task failed: 'fcp' is undefined"
}

To ensure the fcp is not interpret before the old and obsolete "with_items" variable, use the "when" correctly.
