### PR TITLE
fix: fix deprecation warnings due to imports

### DIFF
--- a/.ansible/collections/ansible_collections/netapp/ontap/changelogs/fragments/338-fix-import-deprecation-warnings.yml
+++ b/.ansible/collections/ansible_collections/netapp/ontap/changelogs/fragments/338-fix-import-deprecation-warnings.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - modules and module utils - fix deprecation warning when importing the `to_native`, `to_text` and `to_bytes` functions by using the new import path

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/filter/na_filter_iso8601.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/filter/na_filter_iso8601.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.errors import AnsibleFilterError
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 IMPORT_ERROR = None
 try:

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/module_utils/netapp.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/module_utils/netapp.py
@@ -42,7 +42,7 @@ import os
 import ssl
 import time
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from ansible.module_utils.ansible_release import __version__ as ANSIBLE_VERSION

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/module_utils/netapp_ipaddress.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/module_utils/netapp_ipaddress.py
@@ -34,7 +34,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     import ipaddress

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/module_utils/zapis_svm.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/module_utils/zapis_svm.py
@@ -36,7 +36,7 @@ __metaclass__ = type
 
 import traceback
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 
 

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_active_directory.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_active_directory.py
@@ -122,7 +122,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_aggregate.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_aggregate.py
@@ -346,7 +346,7 @@ import time
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_autosupport.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_autosupport.py
@@ -258,7 +258,7 @@ import re
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_autosupport_invoke.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_autosupport_invoke.py
@@ -77,7 +77,7 @@ RETURN = '''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_autoupdate_config.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_autoupdate_config.py
@@ -59,7 +59,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_bgp_config.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_bgp_config.py
@@ -97,7 +97,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_bgp_peer_group.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_bgp_peer_group.py
@@ -210,7 +210,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, netapp_ipaddress

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_broadcast_domain.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_broadcast_domain.py
@@ -187,7 +187,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_broadcast_domain_ports.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_broadcast_domain_ports.py
@@ -71,7 +71,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cg.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cg.py
@@ -559,7 +559,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cg_snapshot.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cg_snapshot.py
@@ -138,7 +138,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs.py
@@ -286,7 +286,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs_acl.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs_acl.py
@@ -118,7 +118,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs_local_group_member.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs_local_group_member.py
@@ -106,7 +106,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs_local_user.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs_local_user.py
@@ -135,7 +135,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs_local_user_modify.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs_local_user_modify.py
@@ -77,7 +77,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs_local_user_set_password.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs_local_user_set_password.py
@@ -86,7 +86,7 @@ RETURN = '''
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs_privileges.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs_privileges.py
@@ -121,7 +121,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_vserver

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs_server.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs_server.py
@@ -318,7 +318,7 @@ RETURN = '''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs_unix_symlink_mapping.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cifs_unix_symlink_mapping.py
@@ -145,7 +145,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cli_timeout.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cli_timeout.py
@@ -61,7 +61,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cluster.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cluster.py
@@ -191,7 +191,7 @@ import time
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cluster_ha.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cluster_ha.py
@@ -39,7 +39,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cluster_peer.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_cluster_peer.py
@@ -190,7 +190,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_command.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_command.py
@@ -103,7 +103,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 
 

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_debug.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_debug.py
@@ -74,7 +74,7 @@ RETURN = """
 """
 import sys
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.rest_user import get_users

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_disks.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_disks.py
@@ -76,7 +76,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_dns.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_dns.py
@@ -110,7 +110,7 @@ RETURN = """
 """
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_efficiency_policy.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_efficiency_policy.py
@@ -151,7 +151,7 @@ import traceback
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic
 

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ems_config.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ems_config.py
@@ -92,7 +92,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ems_filter.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ems_filter.py
@@ -132,7 +132,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_export_policy.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_export_policy.py
@@ -103,7 +103,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_export_policy_rule.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_export_policy_rule.py
@@ -241,7 +241,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_fcp.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_fcp.py
@@ -55,7 +55,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_file_directory_policy.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_file_directory_policy.py
@@ -134,7 +134,7 @@ import traceback
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 HAS_NETAPP_LIB = netapp_utils.has_netapp_lib()
 

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_file_security_permissions.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_file_security_permissions.py
@@ -316,7 +316,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_vserver

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_file_security_permissions_acl.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_file_security_permissions_acl.py
@@ -252,7 +252,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_vserver

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_firewall_policy.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_firewall_policy.py
@@ -111,7 +111,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import netapp_ipaddress

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_firmware_upgrade.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_firmware_upgrade.py
@@ -285,7 +285,7 @@ msg:
 import time
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_flexcache.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_flexcache.py
@@ -275,7 +275,7 @@ RETURN = """
 import time
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_volume

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_fpolicy_event.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_fpolicy_event.py
@@ -108,7 +108,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_fpolicy_ext_engine.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_fpolicy_ext_engine.py
@@ -159,7 +159,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_fpolicy_policy.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_fpolicy_policy.py
@@ -115,7 +115,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_fpolicy_scope.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_fpolicy_scope.py
@@ -138,7 +138,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_fpolicy_status.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_fpolicy_status.py
@@ -75,7 +75,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_igroup.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_igroup.py
@@ -229,7 +229,7 @@ RETURN = '''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_igroup_initiator.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_igroup_initiator.py
@@ -110,7 +110,7 @@ RETURN = '''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_info.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_info.py
@@ -376,7 +376,7 @@ import codecs
 import copy
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 
 IMPORT_ERRORS = []

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_interface.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_interface.py
@@ -428,7 +428,7 @@ RETURN = """
 import time
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ipspace.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ipspace.py
@@ -79,7 +79,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_iscsi.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_iscsi.py
@@ -116,7 +116,7 @@ RETURN = """
 import traceback
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_job_schedule.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_job_schedule.py
@@ -210,7 +210,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_kerberos_interface.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_kerberos_interface.py
@@ -117,7 +117,7 @@ RETURN = '''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_kerberos_realm.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_kerberos_realm.py
@@ -166,7 +166,7 @@ RETURN = '''
 import traceback
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic
 

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ldap.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ldap.py
@@ -66,7 +66,7 @@ RETURN = '''
 import traceback
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 
 

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ldap_client.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ldap_client.py
@@ -226,7 +226,7 @@ RETURN = '''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_license.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_license.py
@@ -195,7 +195,7 @@ import time
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_local_hosts.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_local_hosts.py
@@ -107,7 +107,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, netapp_ipaddress

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_log_forward.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_log_forward.py
@@ -100,7 +100,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_login_messages.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_login_messages.py
@@ -79,7 +79,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_lun.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_lun.py
@@ -381,7 +381,7 @@ import copy
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.rest_application import RestApplication

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_lun_copy.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_lun_copy.py
@@ -102,7 +102,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_ontap_personality

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_lun_map.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_lun_map.py
@@ -139,10 +139,10 @@ lun_size:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 import codecs
-from ansible.module_utils._text import to_text, to_bytes
+from ansible.module_utils.common.text.converters import to_text, to_bytes
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_ontap_personality

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_lun_map_reporting_nodes.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_lun_map_reporting_nodes.py
@@ -118,7 +118,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_ontap_personality

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_mav_approval_group.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_mav_approval_group.py
@@ -90,7 +90,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_mav_config.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_mav_config.py
@@ -120,7 +120,7 @@ request_info:
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_mav_rule.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_mav_rule.py
@@ -121,7 +121,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_motd.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_motd.py
@@ -86,7 +86,7 @@ RETURN = '''
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_name_service_switch.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_name_service_switch.py
@@ -93,7 +93,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_vserver

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ndmp.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ndmp.py
@@ -189,7 +189,7 @@ RETURN = '''
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_net_ifgrp.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_net_ifgrp.py
@@ -195,7 +195,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_net_port.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_net_port.py
@@ -102,7 +102,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_net_routes.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_net_routes.py
@@ -109,7 +109,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_net_subnet.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_net_subnet.py
@@ -107,7 +107,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_net_vlan.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_net_vlan.py
@@ -120,7 +120,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_nfs.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_nfs.py
@@ -427,7 +427,7 @@ RETURN = """
 """
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_node.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_node.py
@@ -77,7 +77,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ntfs_dacl.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ntfs_dacl.py
@@ -121,7 +121,7 @@ RETURN = """
 import traceback
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 
 HAS_NETAPP_LIB = netapp_utils.has_netapp_lib()

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ntfs_sd.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ntfs_sd.py
@@ -129,7 +129,7 @@ import traceback
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 HAS_NETAPP_LIB = netapp_utils.has_netapp_lib()
 

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ntp.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ntp.py
@@ -66,7 +66,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ntp_key.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ntp_key.py
@@ -66,7 +66,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_nvme.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_nvme.py
@@ -65,7 +65,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_nvme_namespace.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_nvme_namespace.py
@@ -131,7 +131,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_nvme_subsystem.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_nvme_subsystem.py
@@ -117,7 +117,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_ontap_personality

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_object_store.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_object_store.py
@@ -130,7 +130,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ports.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ports.py
@@ -128,7 +128,7 @@ RETURN = '''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_portset.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_portset.py
@@ -98,7 +98,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_qos_adaptive_policy_group.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_qos_adaptive_policy_group.py
@@ -131,7 +131,7 @@ import traceback
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class NetAppOntapAdaptiveQosPolicyGroup:

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_qos_policy_group.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_qos_policy_group.py
@@ -286,7 +286,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_qtree.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_qtree.py
@@ -228,7 +228,7 @@ RETURN = """
 """
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_quota_policy.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_quota_policy.py
@@ -95,7 +95,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils import zapis_svm

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_quotas.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_quotas.py
@@ -277,7 +277,7 @@ import time
 import traceback
 import re
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_rest_info.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_rest_info.py
@@ -469,7 +469,7 @@ EXAMPLES = '''
 
 import codecs
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_text, to_bytes
+from ansible.module_utils.common.text.converters import to_text, to_bytes
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_s3_buckets.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_s3_buckets.py
@@ -332,7 +332,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_s3_groups.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_s3_groups.py
@@ -125,7 +125,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_s3_policies.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_s3_policies.py
@@ -156,7 +156,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_s3_services.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_s3_services.py
@@ -172,7 +172,7 @@ s3_service_info:
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_s3_users.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_s3_users.py
@@ -136,7 +136,7 @@ access_key:
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_security_config.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_security_config.py
@@ -90,7 +90,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_security_ipsec_ca_certificate.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_security_ipsec_ca_certificate.py
@@ -87,7 +87,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_security_ipsec_config.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_security_ipsec_config.py
@@ -66,7 +66,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_security_ipsec_policy.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_security_ipsec_policy.py
@@ -257,7 +257,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, netapp_ipaddress

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_security_key_manager.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_security_key_manager.py
@@ -168,7 +168,7 @@ RETURN = """
 import time
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_service_processor_network.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_service_processor_network.py
@@ -141,7 +141,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_snaplock_clock.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_snaplock_clock.py
@@ -43,7 +43,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_snapmirror.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_snapmirror.py
@@ -559,7 +559,7 @@ import re
 import time
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_elementsw_module import NaElementSWModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_snapmirror_policy.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_snapmirror_policy.py
@@ -322,7 +322,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_snapshot.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_snapshot.py
@@ -151,7 +151,7 @@ import traceback
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_volume
 

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_snapshot_policy.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_snapshot_policy.py
@@ -185,7 +185,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_snmp.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_snmp.py
@@ -145,7 +145,7 @@ RETURN = """
 """
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_snmp_config.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_snmp_config.py
@@ -73,7 +73,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_software_update.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_software_update.py
@@ -149,7 +149,7 @@ validation_reports_after_updates:
 import time
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ssh_command.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ssh_command.py
@@ -111,7 +111,7 @@ stdout_lines_filtered:
 import traceback
 import warnings
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 
 try:

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_storage_auto_giveback.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_storage_auto_giveback.py
@@ -65,7 +65,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_storage_failover.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_storage_failover.py
@@ -57,7 +57,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_storage_unit.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_storage_unit.py
@@ -194,7 +194,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_storage_unit_snapshot.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_storage_unit_snapshot.py
@@ -134,7 +134,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_svm.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_svm.py
@@ -423,7 +423,7 @@ import copy
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_svm_options.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_svm_options.py
@@ -54,7 +54,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ucadapter.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_ucadapter.py
@@ -82,7 +82,7 @@ RETURN = '''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_unix_group.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_unix_group.py
@@ -103,7 +103,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_unix_user.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_unix_user.py
@@ -102,7 +102,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_user.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_user.py
@@ -268,7 +268,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_user_role.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_user_role.py
@@ -185,7 +185,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_volume.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_volume.py
@@ -1083,7 +1083,7 @@ RETURN = """
 import time
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.rest_application import RestApplication

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_volume_autosize.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_volume_autosize.py
@@ -147,7 +147,7 @@ RETURN = """
 import copy
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_volume_clone.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_volume_clone.py
@@ -165,7 +165,7 @@ RETURN = """
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_volume_efficiency.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_volume_efficiency.py
@@ -289,7 +289,7 @@ RETURN = """
 import copy
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_volume_snaplock.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_volume_snaplock.py
@@ -121,7 +121,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 
 HAS_NETAPP_LIB = netapp_utils.has_netapp_lib()

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_vscan.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_vscan.py
@@ -65,7 +65,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_vscan_on_access_policy.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_vscan_on_access_policy.py
@@ -149,7 +149,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_vscan_on_demand_task.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_vscan_on_demand_task.py
@@ -158,7 +158,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_vscan_scanner_pool.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_vscan_scanner_pool.py
@@ -104,7 +104,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_vserver_cifs_security.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_vserver_cifs_security.py
@@ -161,7 +161,7 @@ RETURN = '''
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_vserver_peer.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_vserver_peer.py
@@ -146,7 +146,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_wait_for_condition.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_wait_for_condition.py
@@ -153,7 +153,7 @@ last_state:
 
 import time
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_zapit.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/plugins/modules/na_ontap_zapit.py
@@ -160,7 +160,7 @@ reason:
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 
 try:

--- a/.ansible/collections/ansible_collections/netapp/ontap/tests/unit/plugins/module_utils/ansible_mocks.py
+++ b/.ansible/collections/ansible_collections/netapp/ontap/tests/unit/plugins/module_utils/ansible_mocks.py
@@ -8,7 +8,7 @@ import json
 import pytest
 import sys
 from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible_collections.netapp.ontap.tests.unit.compat.mock import patch
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import ZAPI_DEPRECATION_MESSAGE

--- a/plugins/filter/na_filter_iso8601.py
+++ b/plugins/filter/na_filter_iso8601.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.errors import AnsibleFilterError
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 IMPORT_ERROR = None
 try:

--- a/plugins/module_utils/netapp.py
+++ b/plugins/module_utils/netapp.py
@@ -42,7 +42,7 @@ import os
 import ssl
 import time
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from ansible.module_utils.ansible_release import __version__ as ANSIBLE_VERSION

--- a/plugins/module_utils/netapp_ipaddress.py
+++ b/plugins/module_utils/netapp_ipaddress.py
@@ -34,7 +34,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     import ipaddress

--- a/plugins/module_utils/zapis_svm.py
+++ b/plugins/module_utils/zapis_svm.py
@@ -36,7 +36,7 @@ __metaclass__ = type
 
 import traceback
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 
 

--- a/plugins/modules/na_ontap_active_directory.py
+++ b/plugins/modules/na_ontap_active_directory.py
@@ -122,7 +122,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_aggregate.py
+++ b/plugins/modules/na_ontap_aggregate.py
@@ -346,7 +346,7 @@ import time
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_autosupport.py
+++ b/plugins/modules/na_ontap_autosupport.py
@@ -258,7 +258,7 @@ import re
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_autosupport_invoke.py
+++ b/plugins/modules/na_ontap_autosupport_invoke.py
@@ -77,7 +77,7 @@ RETURN = '''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils

--- a/plugins/modules/na_ontap_autoupdate_config.py
+++ b/plugins/modules/na_ontap_autoupdate_config.py
@@ -59,7 +59,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_bgp_config.py
+++ b/plugins/modules/na_ontap_bgp_config.py
@@ -97,7 +97,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_bgp_peer_group.py
+++ b/plugins/modules/na_ontap_bgp_peer_group.py
@@ -210,7 +210,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, netapp_ipaddress

--- a/plugins/modules/na_ontap_broadcast_domain.py
+++ b/plugins/modules/na_ontap_broadcast_domain.py
@@ -187,7 +187,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_broadcast_domain_ports.py
+++ b/plugins/modules/na_ontap_broadcast_domain_ports.py
@@ -71,7 +71,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 

--- a/plugins/modules/na_ontap_cg.py
+++ b/plugins/modules/na_ontap_cg.py
@@ -559,7 +559,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_cg_snapshot.py
+++ b/plugins/modules/na_ontap_cg_snapshot.py
@@ -138,7 +138,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_cifs.py
+++ b/plugins/modules/na_ontap_cifs.py
@@ -286,7 +286,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_cifs_acl.py
+++ b/plugins/modules/na_ontap_cifs_acl.py
@@ -118,7 +118,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_cifs_local_group_member.py
+++ b/plugins/modules/na_ontap_cifs_local_group_member.py
@@ -106,7 +106,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_cifs_local_user.py
+++ b/plugins/modules/na_ontap_cifs_local_user.py
@@ -135,7 +135,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_cifs_local_user_modify.py
+++ b/plugins/modules/na_ontap_cifs_local_user_modify.py
@@ -77,7 +77,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_cifs_local_user_set_password.py
+++ b/plugins/modules/na_ontap_cifs_local_user_set_password.py
@@ -86,7 +86,7 @@ RETURN = '''
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_cifs_privileges.py
+++ b/plugins/modules/na_ontap_cifs_privileges.py
@@ -121,7 +121,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_vserver

--- a/plugins/modules/na_ontap_cifs_server.py
+++ b/plugins/modules/na_ontap_cifs_server.py
@@ -318,7 +318,7 @@ RETURN = '''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_cifs_unix_symlink_mapping.py
+++ b/plugins/modules/na_ontap_cifs_unix_symlink_mapping.py
@@ -145,7 +145,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_cli_timeout.py
+++ b/plugins/modules/na_ontap_cli_timeout.py
@@ -61,7 +61,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_cluster.py
+++ b/plugins/modules/na_ontap_cluster.py
@@ -191,7 +191,7 @@ import time
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_cluster_ha.py
+++ b/plugins/modules/na_ontap_cluster_ha.py
@@ -39,7 +39,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_cluster_peer.py
+++ b/plugins/modules/na_ontap_cluster_peer.py
@@ -190,7 +190,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_command.py
+++ b/plugins/modules/na_ontap_command.py
@@ -103,7 +103,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 
 

--- a/plugins/modules/na_ontap_debug.py
+++ b/plugins/modules/na_ontap_debug.py
@@ -74,7 +74,7 @@ RETURN = """
 """
 import sys
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.rest_user import get_users

--- a/plugins/modules/na_ontap_disks.py
+++ b/plugins/modules/na_ontap_disks.py
@@ -76,7 +76,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_dns.py
+++ b/plugins/modules/na_ontap_dns.py
@@ -110,7 +110,7 @@ RETURN = """
 """
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule

--- a/plugins/modules/na_ontap_efficiency_policy.py
+++ b/plugins/modules/na_ontap_efficiency_policy.py
@@ -151,7 +151,7 @@ import traceback
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic
 

--- a/plugins/modules/na_ontap_ems_config.py
+++ b/plugins/modules/na_ontap_ems_config.py
@@ -92,7 +92,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_ems_filter.py
+++ b/plugins/modules/na_ontap_ems_filter.py
@@ -132,7 +132,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_export_policy.py
+++ b/plugins/modules/na_ontap_export_policy.py
@@ -103,7 +103,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_export_policy_rule.py
+++ b/plugins/modules/na_ontap_export_policy_rule.py
@@ -241,7 +241,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule

--- a/plugins/modules/na_ontap_fcp.py
+++ b/plugins/modules/na_ontap_fcp.py
@@ -55,7 +55,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_file_directory_policy.py
+++ b/plugins/modules/na_ontap_file_directory_policy.py
@@ -134,7 +134,7 @@ import traceback
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 HAS_NETAPP_LIB = netapp_utils.has_netapp_lib()
 

--- a/plugins/modules/na_ontap_file_security_permissions.py
+++ b/plugins/modules/na_ontap_file_security_permissions.py
@@ -316,7 +316,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_vserver

--- a/plugins/modules/na_ontap_file_security_permissions_acl.py
+++ b/plugins/modules/na_ontap_file_security_permissions_acl.py
@@ -252,7 +252,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_vserver

--- a/plugins/modules/na_ontap_firewall_policy.py
+++ b/plugins/modules/na_ontap_firewall_policy.py
@@ -111,7 +111,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import netapp_ipaddress

--- a/plugins/modules/na_ontap_firmware_upgrade.py
+++ b/plugins/modules/na_ontap_firmware_upgrade.py
@@ -285,7 +285,7 @@ msg:
 import time
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_flexcache.py
+++ b/plugins/modules/na_ontap_flexcache.py
@@ -275,7 +275,7 @@ RETURN = """
 import time
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_volume

--- a/plugins/modules/na_ontap_fpolicy_event.py
+++ b/plugins/modules/na_ontap_fpolicy_event.py
@@ -108,7 +108,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_fpolicy_ext_engine.py
+++ b/plugins/modules/na_ontap_fpolicy_ext_engine.py
@@ -159,7 +159,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_fpolicy_policy.py
+++ b/plugins/modules/na_ontap_fpolicy_policy.py
@@ -115,7 +115,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_fpolicy_scope.py
+++ b/plugins/modules/na_ontap_fpolicy_scope.py
@@ -138,7 +138,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_fpolicy_status.py
+++ b/plugins/modules/na_ontap_fpolicy_status.py
@@ -75,7 +75,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_igroup.py
+++ b/plugins/modules/na_ontap_igroup.py
@@ -229,7 +229,7 @@ RETURN = '''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_igroup_initiator.py
+++ b/plugins/modules/na_ontap_igroup_initiator.py
@@ -110,7 +110,7 @@ RETURN = '''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_info.py
+++ b/plugins/modules/na_ontap_info.py
@@ -376,7 +376,7 @@ import codecs
 import copy
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 
 IMPORT_ERRORS = []

--- a/plugins/modules/na_ontap_interface.py
+++ b/plugins/modules/na_ontap_interface.py
@@ -428,7 +428,7 @@ RETURN = """
 import time
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_ipspace.py
+++ b/plugins/modules/na_ontap_ipspace.py
@@ -79,7 +79,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_iscsi.py
+++ b/plugins/modules/na_ontap_iscsi.py
@@ -116,7 +116,7 @@ RETURN = """
 import traceback
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_job_schedule.py
+++ b/plugins/modules/na_ontap_job_schedule.py
@@ -210,7 +210,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_kerberos_interface.py
+++ b/plugins/modules/na_ontap_kerberos_interface.py
@@ -117,7 +117,7 @@ RETURN = '''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_kerberos_realm.py
+++ b/plugins/modules/na_ontap_kerberos_realm.py
@@ -166,7 +166,7 @@ RETURN = '''
 import traceback
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic
 

--- a/plugins/modules/na_ontap_ldap.py
+++ b/plugins/modules/na_ontap_ldap.py
@@ -66,7 +66,7 @@ RETURN = '''
 import traceback
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 
 

--- a/plugins/modules/na_ontap_ldap_client.py
+++ b/plugins/modules/na_ontap_ldap_client.py
@@ -226,7 +226,7 @@ RETURN = '''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_license.py
+++ b/plugins/modules/na_ontap_license.py
@@ -195,7 +195,7 @@ import time
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_local_hosts.py
+++ b/plugins/modules/na_ontap_local_hosts.py
@@ -107,7 +107,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, netapp_ipaddress

--- a/plugins/modules/na_ontap_log_forward.py
+++ b/plugins/modules/na_ontap_log_forward.py
@@ -100,7 +100,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_login_messages.py
+++ b/plugins/modules/na_ontap_login_messages.py
@@ -79,7 +79,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_lun.py
+++ b/plugins/modules/na_ontap_lun.py
@@ -381,7 +381,7 @@ import copy
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.rest_application import RestApplication

--- a/plugins/modules/na_ontap_lun_copy.py
+++ b/plugins/modules/na_ontap_lun_copy.py
@@ -102,7 +102,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_ontap_personality

--- a/plugins/modules/na_ontap_lun_map.py
+++ b/plugins/modules/na_ontap_lun_map.py
@@ -139,10 +139,10 @@ lun_size:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 import codecs
-from ansible.module_utils._text import to_text, to_bytes
+from ansible.module_utils.common.text.converters import to_text, to_bytes
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_ontap_personality

--- a/plugins/modules/na_ontap_lun_map_reporting_nodes.py
+++ b/plugins/modules/na_ontap_lun_map_reporting_nodes.py
@@ -118,7 +118,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_ontap_personality

--- a/plugins/modules/na_ontap_mav_approval_group.py
+++ b/plugins/modules/na_ontap_mav_approval_group.py
@@ -90,7 +90,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_mav_config.py
+++ b/plugins/modules/na_ontap_mav_config.py
@@ -120,7 +120,7 @@ request_info:
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_mav_rule.py
+++ b/plugins/modules/na_ontap_mav_rule.py
@@ -121,7 +121,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_motd.py
+++ b/plugins/modules/na_ontap_motd.py
@@ -86,7 +86,7 @@ RETURN = '''
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 

--- a/plugins/modules/na_ontap_name_service_switch.py
+++ b/plugins/modules/na_ontap_name_service_switch.py
@@ -93,7 +93,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_vserver

--- a/plugins/modules/na_ontap_ndmp.py
+++ b/plugins/modules/na_ontap_ndmp.py
@@ -189,7 +189,7 @@ RETURN = '''
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_net_ifgrp.py
+++ b/plugins/modules/na_ontap_net_ifgrp.py
@@ -195,7 +195,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_net_port.py
+++ b/plugins/modules/na_ontap_net_port.py
@@ -102,7 +102,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_net_routes.py
+++ b/plugins/modules/na_ontap_net_routes.py
@@ -109,7 +109,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_net_subnet.py
+++ b/plugins/modules/na_ontap_net_subnet.py
@@ -107,7 +107,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_net_vlan.py
+++ b/plugins/modules/na_ontap_net_vlan.py
@@ -120,7 +120,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_nfs.py
+++ b/plugins/modules/na_ontap_nfs.py
@@ -427,7 +427,7 @@ RETURN = """
 """
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_node.py
+++ b/plugins/modules/na_ontap_node.py
@@ -77,7 +77,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule

--- a/plugins/modules/na_ontap_ntfs_dacl.py
+++ b/plugins/modules/na_ontap_ntfs_dacl.py
@@ -121,7 +121,7 @@ RETURN = """
 import traceback
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 
 HAS_NETAPP_LIB = netapp_utils.has_netapp_lib()

--- a/plugins/modules/na_ontap_ntfs_sd.py
+++ b/plugins/modules/na_ontap_ntfs_sd.py
@@ -129,7 +129,7 @@ import traceback
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 HAS_NETAPP_LIB = netapp_utils.has_netapp_lib()
 

--- a/plugins/modules/na_ontap_ntp.py
+++ b/plugins/modules/na_ontap_ntp.py
@@ -66,7 +66,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_ntp_key.py
+++ b/plugins/modules/na_ontap_ntp_key.py
@@ -66,7 +66,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_nvme.py
+++ b/plugins/modules/na_ontap_nvme.py
@@ -65,7 +65,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_nvme_namespace.py
+++ b/plugins/modules/na_ontap_nvme_namespace.py
@@ -131,7 +131,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_nvme_subsystem.py
+++ b/plugins/modules/na_ontap_nvme_subsystem.py
@@ -117,7 +117,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, rest_ontap_personality

--- a/plugins/modules/na_ontap_object_store.py
+++ b/plugins/modules/na_ontap_object_store.py
@@ -130,7 +130,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_ports.py
+++ b/plugins/modules/na_ontap_ports.py
@@ -128,7 +128,7 @@ RETURN = '''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_portset.py
+++ b/plugins/modules/na_ontap_portset.py
@@ -98,7 +98,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_qos_adaptive_policy_group.py
+++ b/plugins/modules/na_ontap_qos_adaptive_policy_group.py
@@ -131,7 +131,7 @@ import traceback
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class NetAppOntapAdaptiveQosPolicyGroup:

--- a/plugins/modules/na_ontap_qos_policy_group.py
+++ b/plugins/modules/na_ontap_qos_policy_group.py
@@ -286,7 +286,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_qtree.py
+++ b/plugins/modules/na_ontap_qtree.py
@@ -228,7 +228,7 @@ RETURN = """
 """
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_quota_policy.py
+++ b/plugins/modules/na_ontap_quota_policy.py
@@ -95,7 +95,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils import zapis_svm

--- a/plugins/modules/na_ontap_quotas.py
+++ b/plugins/modules/na_ontap_quotas.py
@@ -277,7 +277,7 @@ import time
 import traceback
 import re
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_rest_info.py
+++ b/plugins/modules/na_ontap_rest_info.py
@@ -469,7 +469,7 @@ EXAMPLES = '''
 
 import codecs
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_text, to_bytes
+from ansible.module_utils.common.text.converters import to_text, to_bytes
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_s3_buckets.py
+++ b/plugins/modules/na_ontap_s3_buckets.py
@@ -332,7 +332,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_s3_groups.py
+++ b/plugins/modules/na_ontap_s3_groups.py
@@ -125,7 +125,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_s3_policies.py
+++ b/plugins/modules/na_ontap_s3_policies.py
@@ -156,7 +156,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_s3_services.py
+++ b/plugins/modules/na_ontap_s3_services.py
@@ -172,7 +172,7 @@ s3_service_info:
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_s3_users.py
+++ b/plugins/modules/na_ontap_s3_users.py
@@ -136,7 +136,7 @@ access_key:
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_security_config.py
+++ b/plugins/modules/na_ontap_security_config.py
@@ -90,7 +90,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_security_ipsec_ca_certificate.py
+++ b/plugins/modules/na_ontap_security_ipsec_ca_certificate.py
@@ -87,7 +87,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_security_ipsec_config.py
+++ b/plugins/modules/na_ontap_security_ipsec_config.py
@@ -66,7 +66,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_security_ipsec_policy.py
+++ b/plugins/modules/na_ontap_security_ipsec_policy.py
@@ -257,7 +257,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic, netapp_ipaddress

--- a/plugins/modules/na_ontap_security_key_manager.py
+++ b/plugins/modules/na_ontap_security_key_manager.py
@@ -168,7 +168,7 @@ RETURN = """
 import time
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_service_processor_network.py
+++ b/plugins/modules/na_ontap_service_processor_network.py
@@ -141,7 +141,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_snaplock_clock.py
+++ b/plugins/modules/na_ontap_snaplock_clock.py
@@ -43,7 +43,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_snapmirror.py
+++ b/plugins/modules/na_ontap_snapmirror.py
@@ -559,7 +559,7 @@ import re
 import time
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_elementsw_module import NaElementSWModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule

--- a/plugins/modules/na_ontap_snapmirror_policy.py
+++ b/plugins/modules/na_ontap_snapmirror_policy.py
@@ -322,7 +322,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_snapshot.py
+++ b/plugins/modules/na_ontap_snapshot.py
@@ -151,7 +151,7 @@ import traceback
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_volume
 

--- a/plugins/modules/na_ontap_snapshot_policy.py
+++ b/plugins/modules/na_ontap_snapshot_policy.py
@@ -185,7 +185,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_snmp.py
+++ b/plugins/modules/na_ontap_snmp.py
@@ -145,7 +145,7 @@ RETURN = """
 """
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_snmp_config.py
+++ b/plugins/modules/na_ontap_snmp_config.py
@@ -73,7 +73,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_software_update.py
+++ b/plugins/modules/na_ontap_software_update.py
@@ -149,7 +149,7 @@ validation_reports_after_updates:
 import time
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule

--- a/plugins/modules/na_ontap_ssh_command.py
+++ b/plugins/modules/na_ontap_ssh_command.py
@@ -111,7 +111,7 @@ stdout_lines_filtered:
 import traceback
 import warnings
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 
 try:

--- a/plugins/modules/na_ontap_storage_auto_giveback.py
+++ b/plugins/modules/na_ontap_storage_auto_giveback.py
@@ -65,7 +65,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_storage_failover.py
+++ b/plugins/modules/na_ontap_storage_failover.py
@@ -57,7 +57,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_storage_unit.py
+++ b/plugins/modules/na_ontap_storage_unit.py
@@ -194,7 +194,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_storage_unit_snapshot.py
+++ b/plugins/modules/na_ontap_storage_unit_snapshot.py
@@ -134,7 +134,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_svm.py
+++ b/plugins/modules/na_ontap_svm.py
@@ -423,7 +423,7 @@ import copy
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule

--- a/plugins/modules/na_ontap_svm_options.py
+++ b/plugins/modules/na_ontap_svm_options.py
@@ -54,7 +54,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 

--- a/plugins/modules/na_ontap_ucadapter.py
+++ b/plugins/modules/na_ontap_ucadapter.py
@@ -82,7 +82,7 @@ RETURN = '''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_unix_group.py
+++ b/plugins/modules/na_ontap_unix_group.py
@@ -103,7 +103,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_unix_user.py
+++ b/plugins/modules/na_ontap_unix_user.py
@@ -102,7 +102,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_user.py
+++ b/plugins/modules/na_ontap_user.py
@@ -268,7 +268,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 

--- a/plugins/modules/na_ontap_user_role.py
+++ b/plugins/modules/na_ontap_user_role.py
@@ -185,7 +185,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_volume.py
+++ b/plugins/modules/na_ontap_volume.py
@@ -1083,7 +1083,7 @@ RETURN = """
 import time
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.rest_application import RestApplication

--- a/plugins/modules/na_ontap_volume_autosize.py
+++ b/plugins/modules/na_ontap_volume_autosize.py
@@ -147,7 +147,7 @@ RETURN = """
 import copy
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_volume_clone.py
+++ b/plugins/modules/na_ontap_volume_clone.py
@@ -165,7 +165,7 @@ RETURN = """
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_volume_efficiency.py
+++ b/plugins/modules/na_ontap_volume_efficiency.py
@@ -289,7 +289,7 @@ RETURN = """
 import copy
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_volume_snaplock.py
+++ b/plugins/modules/na_ontap_volume_snaplock.py
@@ -121,7 +121,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 
 HAS_NETAPP_LIB = netapp_utils.has_netapp_lib()

--- a/plugins/modules/na_ontap_vscan.py
+++ b/plugins/modules/na_ontap_vscan.py
@@ -65,7 +65,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule

--- a/plugins/modules/na_ontap_vscan_on_access_policy.py
+++ b/plugins/modules/na_ontap_vscan_on_access_policy.py
@@ -149,7 +149,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_vscan_on_demand_task.py
+++ b/plugins/modules/na_ontap_vscan_on_demand_task.py
@@ -158,7 +158,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_vscan_scanner_pool.py
+++ b/plugins/modules/na_ontap_vscan_scanner_pool.py
@@ -104,7 +104,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule

--- a/plugins/modules/na_ontap_vserver_cifs_security.py
+++ b/plugins/modules/na_ontap_vserver_cifs_security.py
@@ -161,7 +161,7 @@ RETURN = '''
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 

--- a/plugins/modules/na_ontap_vserver_peer.py
+++ b/plugins/modules/na_ontap_vserver_peer.py
@@ -146,7 +146,7 @@ RETURN = """
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import OntapRestAPI

--- a/plugins/modules/na_ontap_wait_for_condition.py
+++ b/plugins/modules/na_ontap_wait_for_condition.py
@@ -153,7 +153,7 @@ last_state:
 
 import time
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp_module import NetAppModule
 from ansible_collections.netapp.ontap.plugins.module_utils import rest_generic

--- a/plugins/modules/na_ontap_zapit.py
+++ b/plugins/modules/na_ontap_zapit.py
@@ -160,7 +160,7 @@ reason:
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.netapp.ontap.plugins.module_utils.netapp as netapp_utils
 
 try:

--- a/tests/unit/framework/ansible_mocks.py
+++ b/tests/unit/framework/ansible_mocks.py
@@ -31,7 +31,7 @@ import json
 import pytest
 
 from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible_collections.netapp.ontap.tests.unit.compat.mock import patch
 
 

--- a/tests/unit/plugins/module_utils/ansible_mocks.py
+++ b/tests/unit/plugins/module_utils/ansible_mocks.py
@@ -8,7 +8,7 @@ import json
 import pytest
 import sys
 from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible_collections.netapp.ontap.tests.unit.compat.mock import patch
 from ansible_collections.netapp.ontap.plugins.module_utils.netapp import ZAPI_DEPRECATION_MESSAGE


### PR DESCRIPTION
fixes deprecation warnings when importing `to_text`, `to_native` and `to_bytes` functions in the various modules

##### SUMMARY
This fixes the following deprecation warning when running netapp modules :

```
[DEPRECATION WARNING]: Importing 'to_text' from 'ansible.module_utils._text' is deprecated. This feature will be removed from ansible-core version 2.24. Use ansible.module_utils.common.text.converters instead.

[DEPRECATION WARNING]: Importing 'to_bytes' from 'ansible.module_utils._text' is deprecated. This feature will be removed from ansible-core version 2.24. Use ansible.module_utils.common.text.converters instead.

[DEPRECATION WARNING]: Importing 'to_native' from 'ansible.module_utils._text' is deprecated. This feature will be removed from ansible-core version 2.24. Use ansible.module_utils.common.text.converters instead.
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
all modules using the given import statements as well as the module_utils they need
